### PR TITLE
feat: support DLP-specific commands via `vanacli dlp <command>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,11 @@ usage: vanacli <command> <command args>
 vana cli v0.0.1
 
 positional arguments:
-  {root,r,roots,wallet,w,wallets,stake,st,stakes,sudo,su,sudos,info,i}
+  {root,r,roots,wallet,w,wallets,stake,st,stakes,su,info,i}
     root (r, roots)     Commands for managing and viewing the root network.
     wallet (w, wallets)
                         Commands for managing and viewing wallets.
     stake (st, stakes)  Commands for staking and removing stake from hotkey accounts.
-    sudo (su, sudos)    Commands for DLP management
     info (i)            Instructions for enabling autocompletion for the CLI.
 
 options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vana"
-version = "0.2.2"
+version = "0.3.0"
 description = ""
 authors = ["Tim Nunamaker <tim@vana.com>", "Volodymyr Isai <volod@vana.com>", "Kahtaf Alam <kahtaf@vana.com>"]
 readme = "README.md"

--- a/vana/chain_manager.py
+++ b/vana/chain_manager.py
@@ -24,16 +24,15 @@ from decimal import Decimal
 from typing import Optional, List, Union
 
 import redis
+import vana
 from eth_account.signers.local import LocalAccount
 from retry import retry
 from rich.prompt import Confirm
+from vana.utils.misc import get_block_explorer_url
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.exceptions import TransactionNotFound
 from web3.middleware import geth_poa_middleware
-
-import vana
-from vana.utils.misc import get_block_explorer_url
 
 logger = native_logging.getLogger("opendata")
 
@@ -110,8 +109,6 @@ class ChainManager:
             config = self.config()
         self.config = copy.deepcopy(config)
 
-        # self.chain_endpoint, self.network = ChainManager.setup_config(self.config.chain.network, config)
-        # TODO: is this an issue?
         self.config.chain.chain_endpoint, self.config.chain.network = ChainManager.setup_config(
             self.config.chain.network, config)
 
@@ -162,18 +159,6 @@ class ChainManager:
         except argparse.ArgumentError:
             # re-parsing arguments.
             pass
-
-    def register(
-            self,
-            wallet: "vana.Wallet",
-            dlpuid: int
-    ) -> bool:
-        """
-        Registers a node on the network using the provided wallet.
-        TODO: Temporarily using Redis, but this should be sent to a smart contract.
-        """
-        self.db.sadd(f"{self.db_namespace}:hotkeys", wallet.hotkey.address)
-        return True
 
     def serve_node_server(
             self,

--- a/vana/cli.py
+++ b/vana/cli.py
@@ -18,13 +18,12 @@
 # DEALINGS IN THE SOFTWARE.
 
 import argparse
+import shtab
 import sys
+import vana
 from importlib.metadata import entry_points
 from typing import List, Optional
 
-import shtab
-
-import vana
 from .commands import (
     GetWalletHistoryCommand,
     NewColdkeyCommand,
@@ -45,15 +44,14 @@ ALIAS_TO_COMMAND = {
     "root": "root",
     "wallet": "wallet",
     "stake": "stake",
-    "sudo": "sudo",
     "r": "root",
     "w": "wallet",
     "st": "stake",
-    "su": "sudo",
     "roots": "root",
     "wallets": "wallet",
     "stakes": "stake",
-    "sudos": "sudo",
+    "dlp": "dlp",
+    "d": "dlp",
     "i": "info",
     "info": "info",
 }
@@ -91,10 +89,10 @@ COMMANDS = {
 
         },
     },
-    "sudo": {
-        "name": "sudo",
-        "aliases": ["su", "sudos"],
-        "help": "Commands for DLP management",
+    "dlp": {
+        "name": "dlp",
+        "aliases": ["d"],
+        "help": "DLP-specific commands for DLP management",
         "commands": {
 
         },
@@ -118,13 +116,8 @@ def load_external_commands():
     for entry_point in eps:
         command = entry_point.load()
         command_name = command.__name__.lower().replace('command', '')
-        COMMANDS[command_name] = {
-            "name": command_name,
-            "aliases": [],  # TODO, support external command aliases
-            "help": command.__doc__.strip().split('\n')[0],
-            "commands": {
-                command_name: command,
-            },
+        COMMANDS["dlp"]["commands"] = {
+            command_name: command,
         }
 
 

--- a/vana/commands/base_command.py
+++ b/vana/commands/base_command.py
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+# Copyright © 2024 Corsali, Inc. dba Vana
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import argparse
+import vana
+
+
+class BaseCommand:
+
+    @staticmethod
+    def run(cli: "vana.cli"):
+        pass
+
+    @staticmethod
+    def add_args(parser: argparse.ArgumentParser):
+        pass
+
+    @staticmethod
+    def check_config(config: "vana.Config"):
+        pass

--- a/vana/commands/transfer.py
+++ b/vana/commands/transfer.py
@@ -17,16 +17,16 @@
 
 import argparse
 import sys
-
-from rich.prompt import Prompt
-
 import vana
+from rich.prompt import Prompt
+from vana.commands.base_command import BaseCommand
+
 from . import defaults
 
 console = vana.__console__
 
 
-class TransferCommand:
+class TransferCommand(BaseCommand):
     """
     Executes the ``transfer`` command to transfer DAT tokens from one account to another on the Vana network.
 

--- a/vana/commands/wallets.py
+++ b/vana/commands/wallets.py
@@ -17,18 +17,18 @@
 
 import argparse
 import os
-import sys
-from typing import Optional, List, Tuple
-
 import requests
+import sys
+import vana
 from rich.prompt import Prompt, Confirm
 from rich.table import Table
+from typing import Optional, List, Tuple
+from vana.commands.base_command import BaseCommand
 
-import vana
 from . import defaults
 
 
-class RegenColdkeyCommand:
+class RegenColdkeyCommand(BaseCommand):
     """
     Executes the ``regen_coldkey`` command to regenerate a coldkey for a wallet on the Vana network.
 
@@ -152,7 +152,7 @@ class RegenColdkeyCommand:
         # vana.ChainManager.add_args(regen_coldkey_parser)
 
 
-class RegenColdkeypubCommand:
+class RegenColdkeypubCommand(BaseCommand):
     """
     Executes the ``regen_coldkeypub`` command to regenerate the public part of a coldkey (coldkeypub) for a wallet on the Vana network.
 
@@ -239,7 +239,7 @@ class RegenColdkeypubCommand:
         vana.ChainManager.add_args(regen_coldkeypub_parser)
 
 
-class RegenHotkeyCommand:
+class RegenHotkeyCommand(BaseCommand):
     """
     Executes the ``regen_hotkey`` command to regenerate a hotkey for a wallet on the Vana network.
 
@@ -370,7 +370,7 @@ class RegenHotkeyCommand:
         vana.Wallet.add_args(regen_hotkey_parser)
 
 
-class NewHotkeyCommand:
+class NewHotkeyCommand(BaseCommand):
     """
     Executes the ``new_hotkey`` command to create a new hotkey under a wallet on the Vana network.
 
@@ -448,7 +448,7 @@ class NewHotkeyCommand:
         vana.Wallet.add_args(new_hotkey_parser)
 
 
-class NewColdkeyCommand:
+class NewColdkeyCommand(BaseCommand):
     """
     Executes the ``new_coldkey`` command to create a new coldkey under a wallet on the Vana network.
 
@@ -522,7 +522,7 @@ class NewColdkeyCommand:
         vana.Wallet.add_args(new_coldkey_parser)
 
 
-class WalletCreateCommand:
+class WalletCreateCommand(BaseCommand):
     """
     Executes the ``create`` command to generate both a new coldkey and hotkey under a specified wallet on the Vana network.
 
@@ -622,7 +622,7 @@ def _get_coldkey_wallets_for_path(path: str) -> List["vana.Wallet"]:
     return wallets
 
 
-class UpdateWalletCommand:
+class UpdateWalletCommand(BaseCommand):
     """
     Executes the ``update`` command to check and potentially update the security of the wallets in the Vana network.
 
@@ -717,7 +717,7 @@ def _get_coldkey_h160_addresses_for_path(path: str) -> Tuple[List[str], List[str
     return addresses, wallet_names
 
 
-class WalletBalanceCommand:
+class WalletBalanceCommand(BaseCommand):
     """
     Executes the ``balance`` command to check the balance of the wallet on the Vana network.
 
@@ -958,7 +958,7 @@ query ($first: Int!, $after: Cursor, $filter: TransferFilter, $order: [Transfers
 """
 
 
-class GetWalletHistoryCommand:
+class GetWalletHistoryCommand(BaseCommand):
     """
     Executes the ``history`` command to fetch the latest transfers of the provided wallet on the Vana network.
 


### PR DESCRIPTION
Using python entry points, allow DLPs to register arbritary CLI commands, which can be executed via `vanacli dlp <command>`. 