### PR TITLE
feat: decode custom contract error messages for read operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vana"
-version = "0.5.0"
+version = "0.6.0"
 description = ""
 authors = ["Tim Nunamaker <tim@vana.com>", "Volodymyr Isai <volod@vana.com>", "Kahtaf Alam <kahtaf@vana.com>"]
 readme = "README.md"

--- a/vana/chain_manager.py
+++ b/vana/chain_manager.py
@@ -19,21 +19,23 @@ import argparse
 import copy
 import logging as native_logging
 import os
-import redis
 import time
-import vana
 from decimal import Decimal
+from typing import Optional, List, Union
+
+import redis
 from eth_account.signers.local import LocalAccount
 from retry import retry
 from rich.prompt import Confirm
-from typing import Optional, List, Union
-from vana.utils.misc import get_block_explorer_url
-from vana.utils.web3 import decode_custom_error
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from web3.exceptions import ContractCustomError
 from web3.exceptions import TransactionNotFound
 from web3.middleware import geth_poa_middleware
+
+import vana
+from vana.utils.misc import get_block_explorer_url
+from vana.utils.web3 import decode_custom_error
 
 logger = native_logging.getLogger("opendata")
 
@@ -245,9 +247,18 @@ class ChainManager:
             return tx_hash, tx_receipt
         except ContractCustomError as e:
             decoded_error = decode_custom_error(function.contract_abi, e.data)
-            vana.logging.error(f"Failed to call contract function: {decoded_error}")
+            vana.logging.error(f"Failed to write to contract function: {decoded_error}")
         except Exception as e:
-            vana.logging.error(f"Failed to call contract function: {e}")
+            vana.logging.error(f"Failed to write to contract function: {e}")
+
+    def read_contract_fn(self, function: ContractFunction):
+        try:
+            return function.call()
+        except ContractCustomError as e:
+            decoded_error = decode_custom_error(function.contract_abi, e.data)
+            vana.logging.error(f"Failed to read from contract function: {decoded_error}")
+        except Exception as e:
+            vana.logging.error(f"Failed to read from contract function: {e}")
 
     def get_current_block(self) -> int:
         """


### PR DESCRIPTION
Follow up to #17, this adds support for decoding errors from read-only contract functions. 