### PR TITLE
Allow overriding the network chain endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You should be able to view your keys by navigating to `~/.vana/wallets`
 ```bash
 $ tree ~/.vana/
     .vana/                  # Root directory.
-        wallets/                # The folder containing all opendata wallets.
+        wallets/                # The folder containing all vana wallets.
             default/            # The name of your wallet, "default"
                 coldkey         # Your encrypted coldkey.
                 coldkeypub.txt  # Your coldkey public address

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vana"
-version = "0.29.0"
+version = "0.30.0"
 description = ""
 authors = ["Tim Nunamaker <tim@vana.com>", "Volodymyr Isai <volod@vana.com>", "Kahtaf Alam <kahtaf@vana.com>"]
 readme = "README.md"

--- a/vana/__init__.py
+++ b/vana/__init__.py
@@ -15,7 +15,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"
 
 import rich
 
@@ -119,9 +119,13 @@ def debug(on: bool = True):
     logging.set_debug(on)
 
 
-__networks__ = ["vana", "satori", "moksha", "local", "test", "archive"]
+__networks__ = ["vana", "islander", "maya", "satori", "moksha", "local", "test", "archive"]
 
 __vana_entrypoint__ = "https://rpc.vana.org"
+
+__islander_entrypoint__ = "https://rpc.islander.vana.org"
+
+__maya_entrypoint__ = "https://rpc.maya.vana.org"
 
 __satori_entrypoint__ = "https://rpc.satori.vana.org"
 
@@ -135,6 +139,8 @@ block_explorer_tx_templates = {
     "vana": "https://vanascan.io/tx/{}",
     "moksha": "https://moksha.vanascan.io/tx/{}",
     "satori": "https://satori.vanascan.io/tx/{}",
+    "islander": "https://islander.vanascan.io/tx/{}",
+    "maya": "https://maya.vanascan.io/tx/{}",
 }
 
 configs = [

--- a/vana/commands/transfer.py
+++ b/vana/commands/transfer.py
@@ -84,7 +84,7 @@ class TransferCommand(BaseCommand):
         # Get destination.
         if not config.dest and not config.no_prompt:
             dest = Prompt.ask("Enter destination public key: (h160 or secp256k1)")
-            if not vana.utils.is_valid_opendata_address_or_public_key(dest):
+            if not vana.utils.is_valid_vana_address_or_public_key(dest):
                 sys.exit()
             else:
                 config.dest = str(dest)

--- a/vana/commands/wallets.py
+++ b/vana/commands/wallets.py
@@ -200,7 +200,7 @@ class RegenColdkeypubCommand(BaseCommand):
                 config.public_key_hex = prompt_answer
             else:
                 config.h160_address = prompt_answer
-        if not vana.utils.is_valid_opendata_address_or_public_key(
+        if not vana.utils.is_valid_vana_address_or_public_key(
                 address=(
                         config.h160_address if config.h160_address else config.public_key_hex
                 )

--- a/vana/contracts/__init__.py
+++ b/vana/contracts/__init__.py
@@ -4,6 +4,16 @@ contracts = {
         "DataRegistry": "0xEA882bb75C54DE9A08bC46b46c396727B4BFe9a5",
         "RootNetworkContract": "0xf408A064d640b620219F510963646Ed2bD5606BB",
     },
+    "islander": {
+        "TeePool": "0xF084Ca24B4E29Aa843898e0B12c465fAFD089965",
+        "DataRegistry": "0xEA882bb75C54DE9A08bC46b46c396727B4BFe9a5",
+        "RootNetworkContract": "0xf408A064d640b620219F510963646Ed2bD5606BB",
+    },
+    "maya": {
+        "TeePool": "0xF084Ca24B4E29Aa843898e0B12c465fAFD089965",
+        "DataRegistry": "0xEA882bb75C54DE9A08bC46b46c396727B4BFe9a5",
+        "RootNetworkContract": "0xf408A064d640b620219F510963646Ed2bD5606BB",
+    },
     "satori": {
         "TeePool": "0xF084Ca24B4E29Aa843898e0B12c465fAFD089965",
         "DataRegistry": "0xEA882bb75C54DE9A08bC46b46c396727B4BFe9a5",

--- a/vana/logging/defines.py
+++ b/vana/logging/defines.py
@@ -20,7 +20,7 @@ TRACE_LOG_FORMAT = (
     f"%(asctime)s | %(levelname)s | %(name)s:%(filename)s:%(lineno)s | %(message)s"
 )
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-OPENDATA_LOGGER_NAME = "vana"
+VANA_LOGGER_NAME = "vana"
 DEFAULT_LOG_FILE_NAME = "vana.log"
 DEFAULT_MAX_ROTATING_LOG_FILE_SIZE = 25 * 1024 * 1024
 DEFAULT_LOG_BACKUP_COUNT = 10

--- a/vana/logging/loggingmachine.py
+++ b/vana/logging/loggingmachine.py
@@ -31,7 +31,7 @@ import vana
 from vana.logging.defines import (
     TRACE_LOG_FORMAT,
     DATE_FORMAT,
-    OPENDATA_LOGGER_NAME,
+    VANA_LOGGER_NAME,
     DEFAULT_LOG_FILE_NAME,
     DEFAULT_MAX_ROTATING_LOG_FILE_SIZE,
     DEFAULT_LOG_BACKUP_COUNT,
@@ -49,7 +49,7 @@ class LoggingConfig(NamedTuple):
 
 class LoggingMachine(StateMachine):
     """
-    Handles logger states for opendata and 3rd party libraries
+    Handles logger states for vana and 3rd party libraries
     """
 
     Default = State(initial=True)
@@ -83,7 +83,7 @@ class LoggingMachine(StateMachine):
             | Disabled.to(Disabled)
     )
 
-    def __init__(self, config: "vana.Config", name: str = OPENDATA_LOGGER_NAME):
+    def __init__(self, config: "vana.Config", name: str = VANA_LOGGER_NAME):
         # basics
         super(LoggingMachine, self).__init__()
         self._queue = mp.Queue(-1)
@@ -362,13 +362,13 @@ class LoggingMachine(StateMachine):
             parser.add_argument(
                 "--" + prefix_str + "logging.debug",
                 action="store_true",
-                help="""Turn on opendata debugging information""",
+                help="""Turn on vana debugging information""",
                 default=default_logging_debug,
             )
             parser.add_argument(
                 "--" + prefix_str + "logging.trace",
                 action="store_true",
-                help="""Turn on opendata trace level information""",
+                help="""Turn on vana trace level information""",
                 default=default_logging_trace,
             )
             parser.add_argument(

--- a/vana/message.py
+++ b/vana/message.py
@@ -198,10 +198,10 @@ class TerminalInfo(pydantic.BaseModel):
     )
     _extract_port = pydantic.validator("port", pre=True, allow_reuse=True)(cast_int)
 
-    # The opendata version on the terminal as an int.
+    # The vana version on the terminal as an int.
     version: Optional[int] = pydantic.Field(
         title="version",
-        description="The opendata version on the NodeServer as str(int)",
+        description="The vana version on the NodeServer as str(int)",
         examples=111,
         default=None,
         allow_mutation=True,
@@ -229,7 +229,7 @@ class TerminalInfo(pydantic.BaseModel):
         allow_mutation=True,
     )
 
-    # The opendata version on the terminal as an int.
+    # The vana version on the terminal as an int.
     hotkey: Optional[str] = pydantic.Field(
         title="hotkey",
         description="The h160 encoded hotkey string of the terminal wallet.",

--- a/vana/mock/wallet_mock.py
+++ b/vana/mock/wallet_mock.py
@@ -27,11 +27,11 @@ from .. import Wallet, keyfile
 
 class MockWallet(Wallet):
     """
-    Mocked Version of the opendata wallet class, meant to be used for testing.
+    Mocked Version of the vana wallet class, meant to be used for testing.
     """
 
     def __init__(self, **kwargs):
-        r"""Init opendata wallet object containing a hot and coldkey.
+        r"""Init vana wallet object containing a hot and coldkey.
         Args:
             _mock (required=True, default=False):
                 If true creates a mock wallet with random keys.

--- a/vana/utils/wallet_utils.py
+++ b/vana/utils/wallet_utils.py
@@ -54,7 +54,7 @@ def is_valid_secp256k1_pubkey(public_key: Union[str, bytes]) -> bool:
         return False
 
 
-def is_valid_opendata_address_or_public_key(address: Union[str, bytes]) -> bool:
+def is_valid_vana_address_or_public_key(address: Union[str, bytes]) -> bool:
     """
     Checks if the given address is a valid Ethereum address or public key.
 

--- a/vana/wallet.py
+++ b/vana/wallet.py
@@ -29,7 +29,7 @@ from eth_keys.datatypes import PublicKey
 from rich.panel import Panel
 
 import vana
-from vana.utils.wallet_utils import is_valid_opendata_address_or_public_key
+from vana.utils.wallet_utils import is_valid_vana_address_or_public_key
 
 
 def display_private_key_msg(private_key: str, key_type: str):
@@ -618,7 +618,7 @@ class Wallet:
         if h160_address is None and public_key is None:
             raise ValueError("Either h160_address or public_key must be passed")
 
-        if not is_valid_opendata_address_or_public_key(
+        if not is_valid_vana_address_or_public_key(
                 h160_address if h160_address is not None else public_key
         ):
             raise ValueError(


### PR DESCRIPTION
Allow overriding the network chain endpoint using the `CHAIN_NETWORK_ENDPOINT` env var, or the `--chain.chain_network` flag. 

Includes drive by fixes:
- Remove references to opendata
- Add placeholders for maya and islander networks